### PR TITLE
Absolute import paths and deploy script

### DIFF
--- a/deploy/Deployer.sol
+++ b/deploy/Deployer.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.7;
+
+import "../src/Gateway.sol";
+import "../src/SubnetActor.sol";
+import "forge-std/Script.sol";
+
+contract Deployer is Script {
+
+    uint64 constant MIN_COLLATERAL_AMOUNT = 1 ether;
+    uint64 private constant DEFAULT_MIN_VALIDATORS = 1;
+    uint8 private constant DEFAULT_MAJORITY_PERCENTAGE = 70;
+    uint64 constant DEFAULT_CHECKPOINT_PERIOD = 10;
+    uint256 constant CROSS_MSG_FEE = 10 gwei;
+    bytes private constant GENESIS = EMPTY_BYTES;
+    address public constant ROOTNET_ADDRESS = address(0);
+    string private constant DEFAULT_NETWORK_NAME = "test";
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        address[] memory path = new address[](1);
+        path[0] = ROOTNET_ADDRESS;
+
+        Gateway.ConstructorParams memory constructorParams = Gateway.ConstructorParams({
+            networkName: SubnetID({route: path}),
+            bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
+            topDownCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
+            msgFee: CROSS_MSG_FEE,
+            majorityPercentage: DEFAULT_MAJORITY_PERCENTAGE
+        });
+        Gateway gw = new Gateway(constructorParams);
+    
+        SubnetActor.ConstructParams memory subnetConstructorParams = SubnetActor.ConstructParams({
+            parentId: SubnetID({route: path}),
+            name: DEFAULT_NETWORK_NAME,
+            ipcGatewayAddr: address(gw),
+            consensus: ConsensusType.Dummy,
+            minActivationCollateral: MIN_COLLATERAL_AMOUNT,
+            minValidators: DEFAULT_MIN_VALIDATORS,
+            bottomUpCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
+            topDownCheckPeriod: DEFAULT_CHECKPOINT_PERIOD,
+            majorityPercentage: DEFAULT_MAJORITY_PERCENTAGE,
+            genesis: GENESIS
+        });
+
+        new SubnetActor(subnetConstructorParams);
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/lib/AccountHelper.sol
+++ b/src/lib/AccountHelper.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.7;
 
 import "../constants/Constants.sol";
-import "fevmate/utils/FilAddress.sol";
+import "../../lib/fevmate/contracts/utils/FilAddress.sol";
 
 /// @title Helper library for checking account type
 /// @author LimeChain team

--- a/src/lib/CrossMsgHelper.sol
+++ b/src/lib/CrossMsgHelper.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.7;
 import "../structs/Checkpoint.sol";
 import "../constants/Constants.sol";
 import "../lib/SubnetIDHelper.sol";
-import "openzeppelin-contracts/utils/Address.sol";
-import "fevmate/utils/FilAddress.sol";
+import "../../lib/openzeppelin-contracts/contracts/utils/Address.sol";
+import "../../lib/fevmate/contracts/utils/FilAddress.sol";
 
 /// @title Helper library for manipulating StorableMsg struct
 /// @author LimeChain team
@@ -124,7 +124,9 @@ library CrossMsgHelper {
     }
 
     // checks whether the cross messages are sorted in ascending order or not
-    function isSorted(CrossMsg[] calldata crossMsgs) external pure returns(bool) {
+    function isSorted(
+        CrossMsg[] calldata crossMsgs
+    ) external pure returns (bool) {
         uint256 prevNonce = 0;
         for (uint256 i = 0; i < crossMsgs.length; ) {
             uint256 nonce = crossMsgs[i].message.nonce;

--- a/src/lib/SubnetIDHelper.sol
+++ b/src/lib/SubnetIDHelper.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.7;
 
 import "../structs/Subnet.sol";
-import "openzeppelin-contracts/utils/Strings.sol";
+import "../../lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 
 /// @title Helper library for manipulating SubnetID struct
 /// @author LimeChain team
@@ -12,8 +12,13 @@ library SubnetIDHelper {
     bytes32 private constant EMPTY_SUBNET_HASH =
         keccak256(abi.encode(SubnetID(new address[](0))));
 
-    function getParentSubnet(SubnetID memory subnet) public pure returns (SubnetID memory) {
-        require(subnet.route.length > 1, "error getting parent for subnet addr");
+    function getParentSubnet(
+        SubnetID memory subnet
+    ) public pure returns (SubnetID memory) {
+        require(
+            subnet.route.length > 1,
+            "error getting parent for subnet addr"
+        );
 
         address[] memory route = new address[](subnet.route.length - 1);
         for (uint i = 0; i < route.length; ) {
@@ -22,10 +27,8 @@ library SubnetIDHelper {
                 ++i;
             }
         }
-        
-        return SubnetID({
-            route: route
-        });
+
+        return SubnetID({route: route});
     }
 
     function toString(
@@ -47,11 +50,10 @@ library SubnetIDHelper {
         return keccak256(abi.encode(subnet));
     }
 
-    function createSubnetId(SubnetID calldata subnet, address actor)
-        public
-        pure
-        returns (SubnetID memory newSubnet)
-    {
+    function createSubnetId(
+        SubnetID calldata subnet,
+        address actor
+    ) public pure returns (SubnetID memory newSubnet) {
         require(subnet.route.length >= 1, "cannot set actor for empty subnet");
 
         newSubnet.route = new address[](subnet.route.length + 1);
@@ -75,22 +77,20 @@ library SubnetIDHelper {
         return subnet.route.length == 1;
     }
 
-    function equals(SubnetID calldata subnet1, SubnetID calldata subnet2)
-        public
-        pure
-        returns (bool)
-    {
-       if (subnet1.route.length != subnet2.route.length) return false;
-       
-       return toHash(subnet1) == toHash(subnet2);
+    function equals(
+        SubnetID calldata subnet1,
+        SubnetID calldata subnet2
+    ) public pure returns (bool) {
+        if (subnet1.route.length != subnet2.route.length) return false;
+
+        return toHash(subnet1) == toHash(subnet2);
     }
 
     /// @notice Computes the common parent of the current subnet and the one given as argument
-    function commonParent(SubnetID calldata subnet1, SubnetID calldata subnet2)
-        public
-        pure
-        returns (SubnetID memory)
-    {
+    function commonParent(
+        SubnetID calldata subnet1,
+        SubnetID calldata subnet2
+    ) public pure returns (SubnetID memory) {
         uint i = 0;
         while (
             i < subnet1.route.length &&
@@ -127,8 +127,7 @@ library SubnetIDHelper {
 
         uint i = 0;
         while (
-            i < subnet2.route.length &&
-            subnet1.route[i] == subnet2.route[i]
+            i < subnet2.route.length && subnet1.route[i] == subnet2.route[i]
         ) {
             unchecked {
                 i++;
@@ -147,11 +146,11 @@ library SubnetIDHelper {
                 j++;
             }
         }
-        
+
         return SubnetID({route: route});
     }
 
-    function isEmpty(SubnetID calldata subnetId) external pure returns(bool) {
+    function isEmpty(SubnetID calldata subnetId) external pure returns (bool) {
         return toHash(subnetId) == EMPTY_SUBNET_HASH;
     }
 }

--- a/test/AccountHelper.t.sol
+++ b/test/AccountHelper.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.7;
 
-import "forge-std/Test.sol";
+import "../lib/forge-std/src/Test.sol";
 
-import "fevmate/utils/FilAddress.sol";
+import "../lib/fevmate/contracts/utils/FilAddress.sol";
 import "../src/lib/AccountHelper.sol";
 
 contract DummyContract {

--- a/test/SubnetIDHelper.t.sol
+++ b/test/SubnetIDHelper.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.7;
 
-import "forge-std/Test.sol";
-import "openzeppelin-contracts/utils/Strings.sol";
+import "../lib/forge-std/src/Test.sol";
+import "../lib/openzeppelin-contracts/contracts/utils/Strings.sol";
 
 import "../src/lib/SubnetIDHelper.sol";
 
@@ -134,7 +134,6 @@ contract SubnetIDHelperTest is Test {
 
         require(subnetId2.down(subnetId1).equals(subnetId2));
         require(sub3Id.down(subnetId1).equals(subnetId2));
-
     }
 
     function test_ToString_Works_NoRoutes() public view {
@@ -374,8 +373,8 @@ contract SubnetIDHelperTest is Test {
         sub2[2] = SUBNET_TWO_ADDRESS;
         SubnetID memory sub2Id = SubnetID({route: sub2});
 
-        require(isBottomUp(sub1Id,sub2Id) == false);
-        require(isBottomUp(sub2Id,sub2Id) == false);
+        require(isBottomUp(sub1Id, sub2Id) == false);
+        require(isBottomUp(sub2Id, sub2Id) == false);
 
         address[] memory sub3 = new address[](4);
         sub3[0] = ROOT_ADDRESS;
@@ -387,7 +386,6 @@ contract SubnetIDHelperTest is Test {
         require(isBottomUp(sub2Id, sub3Id) == false);
     }
 
-
     function test_IsBottomUp_True() public view {
         address[] memory sub1 = new address[](2);
         sub1[0] = ROOT_ADDRESS;
@@ -398,7 +396,7 @@ contract SubnetIDHelperTest is Test {
         sub2[0] = ROOT_ADDRESS;
         SubnetID memory sub2Id = SubnetID({route: sub2});
 
-        require(isBottomUp(sub1Id,sub2Id) == true);
+        require(isBottomUp(sub1Id, sub2Id) == true);
 
         address[] memory sub3 = new address[](3);
         sub3[0] = ROOT_ADDRESS;
@@ -406,12 +404,14 @@ contract SubnetIDHelperTest is Test {
         sub3[2] = SUBNET_THREE_ADDRESS;
         SubnetID memory sub3Id = SubnetID({route: sub3});
 
-        require(isBottomUp(sub1Id,sub3Id) == true);
+        require(isBottomUp(sub1Id, sub3Id) == true);
     }
- 
+
     function test_Equals_Works_Empty() public view {
         require(EMPTY_SUBNET_ID.equals(EMPTY_SUBNET_ID) == true);
-        require(EMPTY_SUBNET_ID.equals(SubnetID({route: new address[](0)})) == true);
+        require(
+            EMPTY_SUBNET_ID.equals(SubnetID({route: new address[](0)})) == true
+        );
         address[] memory route = new address[](1);
         route[0] = ROOT_ADDRESS;
         require(EMPTY_SUBNET_ID.equals(SubnetID({route: route})) == false);
@@ -426,13 +426,20 @@ contract SubnetIDHelperTest is Test {
         route2[0] = ROOT_ADDRESS;
         route2[1] = SUBNET_TWO_ADDRESS;
 
-        require(SubnetID({route: route}).equals(SubnetID({route: route})) == true);
-        require(SubnetID({route: route}).equals(SubnetID({route: route2})) == false);
+        require(
+            SubnetID({route: route}).equals(SubnetID({route: route})) == true
+        );
+        require(
+            SubnetID({route: route}).equals(SubnetID({route: route2})) == false
+        );
     }
 
-    function isBottomUp(SubnetID memory from, SubnetID memory to) public pure returns (bool){
+    function isBottomUp(
+        SubnetID memory from,
+        SubnetID memory to
+    ) public pure returns (bool) {
         SubnetID memory parent = from.commonParent(to);
-        if(parent.route.length == 0) return false;
+        if (parent.route.length == 0) return false;
         return from.route.length > parent.route.length;
     }
 }


### PR DESCRIPTION
This PR uses absolute paths for imported libraries to avoid the bytecode generated from having pointers to other contracts, that way the output of `forge build` can be used to deploy the contracts manually without requiring foundry. 

This PR also includes the `Deploy.sol` script @mikirov was working on as it may come handy for the deployment of the gateway.